### PR TITLE
adding howList, intro, outro to Recipe type #3

### DIFF
--- a/src/components/NumberedListText.tsx
+++ b/src/components/NumberedListText.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+type NumberedListTextProps = {
+    myList: string[];
+};
+
+export const NumberedListText= ({myList}: NumberedListTextProps) => {
+    return (
+        <ol className="howList">
+            {myList.map((item, index) => (
+                <li key={index}>
+                    {item}
+                </li>
+            ))}
+        </ol>
+        )
+}

--- a/src/pages/RecipePage.tsx
+++ b/src/pages/RecipePage.tsx
@@ -5,6 +5,8 @@ import Footer from "../components/Footer";
 import {Ingredients} from "../components/Ingredients";
 import {useParams} from "react-router-dom";
 import {useRecipes} from "../hooks/useRecipes";
+import React from "react";
+import {NumberedListText} from "../components/NumberedListText";
 
 
 export const RecipePage = () => {
@@ -38,7 +40,7 @@ export const RecipePage = () => {
             <div className="articleContainer">
                 <main>
                     <div className="topContainer">
-                        <img src={recipe?.image} alt={recipe?.title} />
+                        {recipe.image && <img src={recipe.image} alt={recipe.title}/>}
                         {recipe?.ingredients && (
                             <Ingredients items={recipe.ingredients}/>
                         )}
@@ -46,7 +48,13 @@ export const RecipePage = () => {
 
                     <div className="textContent">
                         <h1 id="recipe-title">{recipe?.title}</h1>
-                        <p className="textIntro">{recipe?.description}</p>
+                        <p className="textIntro">{recipe?.introduction}</p>
+                        {recipe.howList &&
+                            <NumberedListText myList={recipe.howList}/>
+                        }
+                        {recipe.outro &&
+                            <p>{recipe.outro}</p>
+                        }
                     </div>
                 </main>
             </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,4 +11,7 @@ export interface Recipe {
     image?: string;
     ingredients?: Ingredient[]
     category?: string;
+    introduction?: string;
+    howList?: string[];
+    outro?: string;
 }


### PR DESCRIPTION
This issue adds a 
- howList
- introduction 
- outro

They are optional and the recipes that don't have the fields will still work.

<img width="697" height="778" alt="image" src="https://github.com/user-attachments/assets/bed844d6-edc6-4fe7-b6b5-0a970349539b" />
